### PR TITLE
Updated single quotes over doubles.

### DIFF
--- a/codeword.rb
+++ b/codeword.rb
@@ -1,5 +1,5 @@
 def codeword(error)
-  error_hash = { 404 => "Page not found.", 502 => "Bad gateway.", 402 => "Page almost found." }
+  error_hash = { 404 => 'Page not found.', 502 => 'Bad gateway.', 402 => 'Page almost found.' }
   message = String.new
   error_hash.each_key { |key|
     if key == error

--- a/test_codeword.rb
+++ b/test_codeword.rb
@@ -10,14 +10,14 @@ class Codeword_Test < Minitest::Test
   end
   def test_codeword_404_return
     code = codeword(404)
-    assert_equal("Page not found.", code)
+    assert_equal('Page not found.', code)
   end
   def test_codeword_502_return
     code = codeword(502)
-    assert_equal("Bad gateway.", code)
+    assert_equal('Bad gateway.', code)
   end
   def test_codeword_402_return
     code = codeword(402)
-    assert_equal("Page almost found.", code)
+    assert_equal('Page almost found.', code)
   end
 end


### PR DESCRIPTION
As per the Ruby convention of using single quotes over doubles except for the string interpolations, I have made the necessary changes.